### PR TITLE
Add Support/Example of using Go's 1.16 embed package

### DIFF
--- a/ebitmx.go
+++ b/ebitmx.go
@@ -2,6 +2,7 @@ package ebitmx
 
 import (
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -12,7 +13,14 @@ import (
 // based on a TMX file. Note that some data might be lost, as Ebiten
 // does not require too much information to render a map
 func GetEbitenMap(path string) (*EbitenMap, error) {
-	tmxFile, err := os.Open(path)
+	return GetEbitenMapFromFS(os.DirFS("."), path)
+}
+
+// GetEbitenMapFromFS allows you to pass in the file system used to find the desired file
+// This is useful for Go's v1.16 embed package which makes it simple to embed assets into
+// your binary and accessible via the embed.FS which is compatible with the fs.FS interface
+func GetEbitenMapFromFS(fileSystem fs.FS, path string) (*EbitenMap, error) {
+	tmxFile, err := fileSystem.Open(path)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error opening TMX file %s: %v", path, err)

--- a/examples/embed.go
+++ b/examples/embed.go
@@ -1,0 +1,7 @@
+package main
+
+import "embed"
+
+// embeddedFS  holds our game assets
+//go:embed map.tmx overworld.png
+var embeddedFS embed.FS

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,9 +1,11 @@
 module github.com/Rulox/ebitmx/examples
 
-go 1.15
+go 1.16
 
 require (
 	github.com/Rulox/ebitmx v0.0.0-20210222233015-c5518eda2662 // indirect
 	github.com/hajimehoshi/ebiten v1.12.8 // indirect
 	github.com/hajimehoshi/ebiten/v2 v2.0.6 // indirect
 )
+
+replace github.com/Rulox/ebitmx => ../

--- a/examples/main.go
+++ b/examples/main.go
@@ -69,7 +69,13 @@ func main() {
 		os.Exit(2)
 	}
 
-	myMap, err := ebitmx.GetEbitenMap("map.tmx")
+	myMapFromEmbedded, err := ebitmx.GetEbitenMapFromFS(embeddedFS, "map.tmx")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(2)
+	}
+
+	_, err = ebitmx.GetEbitenMap("map.tmx")
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(2)
@@ -77,7 +83,7 @@ func main() {
 
 	game := &Game{
 		tiles: tiles,
-		myMap: myMap,
+		myMap: myMapFromEmbedded,
 	}
 
 	if err := ebiten.RunGame(game); err != nil {


### PR DESCRIPTION
Thanks for making this and throwing it on Github. I am messing around with ebiten for the the [7DRL Challenge 2021  (Game Jam)](https://itch.io/jam/7drl-challenge-2021) and found your repo here which saved me a little bit of time. 

I went to generate a binary and realized I could use Go's new [embed ](https://golang.org/pkg/embed/) package to create a single binary to distribute to friends for testing.  Here's the changes I made if you have any interest in incorporating or leaving as an example for others.

